### PR TITLE
v1.0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .kitchen/
 .kitchen.local.yml
 Berksfile.lock
+.DS_Store

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,15 +8,15 @@ provisioner:
     ssl_verify_mode: ":verify_none"
 
 platforms:
-  - name: centos-6.7-vbox
+  - name: centos-6.8-vbox
     driver:
-      box: bento/centos-6.7
-      box_url: bento/centos-6.7
+      box: bento/centos-6.8
+      box_url: bento/centos-6.8
       provider: virtualbox
-  - name: centos-6.7-vmware
+  - name: centos-6.8-vmware
     driver:
-      box: bento/centos-6.7
-      box_url: bento/centos-6.7
+      box: bento/centos-6.8
+      box_url: bento/centos-6.8
       provider: vmware_fusion
   - name: windows-2012r2
 
@@ -30,7 +30,7 @@ suites:
 
 #  NOTE: Once serverspec can autodetect the backend, this won't be needed
   - name: windefault
-    includes:      
+    includes:
       - windows-2012r2
     run_list:
       - recipe[doi_ssl_filtering]
@@ -61,4 +61,3 @@ suites:
       - recipe[doi_ssl_filtering::java]
     data_bags_path: './test/integration/default/data_bags/'
     encrypted_data_bag_secret_key_path: './test/integration/default/encrypted_data_bag_secret'
-

--- a/Berksfile
+++ b/Berksfile
@@ -1,5 +1,3 @@
 source 'https://supermarket.chef.io'
 
 metadata
-
-cookbook 'java'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 DOI SSL Filtering
 =================
 
+v1.0.1
+------
+- [isuftin@usgs.gov] - Java recipe now allows alternate locations for keystore
+- [isuftin@usgs.gov] - Updated Kitchen configuration to use CentOS 6.8 (was 6.7)
+- [isuftin@usgs.gov] - Made community Java cookbook a hard dependency
+
 v1.0.0
 ------
 - [isuftin@usgs.gov] - Updating cookbook to allow for multiple certificates

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -11,3 +11,7 @@ default['doi_ssl_filtering']['cert_locations'] = [
 # This password is stored in an encrypted databag. If the data bag does not exist
 # in your cookbook, the default 'changeit' password will be used
 default['doi_ssl_filtering']['encrypted_data_bag_name'] = 'doi_ssl_filtering_default'
+
+# If this is left blank, the default keystore that will be used will be:
+# $JAVA_HOME/jre/lib/security/cacerts
+default['doi_ssl_filtering']['java']['location']['keystore'] = ''

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,6 +6,7 @@ description 'Installs/Configures openssl and ruby applications for DOI SSL filte
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 issues_url 'https://github.com/USGS-CIDA/chef-cookbook-doi-ssl-filtering/issues'
 source_url 'https://github.com/USGS-CIDA/chef-cookbook-doi-ssl-filtering'
-version '1.0.0'
+version '1.0.1'
 
 depends 'windows', '>= 1.44.3'
+depends 'java', '~> 1.47.0'

--- a/recipes/java.rb
+++ b/recipes/java.rb
@@ -5,6 +5,10 @@
 # Attempts to fix SSL certificate issues with Java
 
 require_relative '../libraries/cert_helpers'
+java_keystore_location = node['doi_ssl_filtering']['java']['location']['keystore']
+if java_keystore_location == ''
+  java_keystore_location = "#{node['java']['java_home']}/jre/lib/security/cacerts"
+end
 
 encrypted_data_bag_name = node['doi_ssl_filtering']['encrypted_data_bag_name']
 begin
@@ -19,7 +23,7 @@ node['doi_ssl_filtering']['cert_locations'].each do |loc|
   original_file = File.join(Chef::Config[:file_cache_path], filename)
 
   execute 'add cert to java keystore' do
-    command "/usr/bin/keytool -keystore $JAVA_HOME/jre/lib/security/cacerts -importcert -alias #{filename} -file #{original_file} -storepass #{java_store_password} -noprompt"
-    not_if "keytool -list -keystore $JAVA_HOME/jre/lib/security/cacerts -v -storepass changeit | grep -q $(/usr/bin/openssl x509 -noout -in #{original_file} -fingerprint -md5 | cut -d '=' -f 2)"
+    command "/usr/bin/keytool -keystore #{java_keystore_location} -importcert -alias #{filename} -file #{original_file} -storepass #{java_store_password} -noprompt"
+    not_if "keytool -list -keystore #{java_keystore_location} -v -storepass #{java_store_password} | grep -q $(/usr/bin/openssl x509 -noout -in #{original_file} -fingerprint -md5 | cut -d '=' -f 2)"
   end
 end


### PR DESCRIPTION
- [isuftin@usgs.gov] - Java recipe now allows alternate locations for keystore
- [isuftin@usgs.gov] - Updated Kitchen configuration to use CentOS 6.8 (was 6.7)
- [isuftin@usgs.gov] - Made community Java cookbook a hard dependency